### PR TITLE
Improve generated code formatting

### DIFF
--- a/src/FsSCAD/Components.fs
+++ b/src/FsSCAD/Components.fs
@@ -1,6 +1,7 @@
 namespace FsSCAD
 
 module Components =
+  open System
 
   type MultiMatrix_Row = float * float * float
   type MultiMatrix = MultiMatrix_Row * MultiMatrix_Row * MultiMatrix_Row
@@ -11,7 +12,7 @@ module Components =
   /// If the value is not within the range of valid hexadecimal color definitions, `ArgumentOutOfRange` exception is raised.
   let HexColor (value: int) =
     if value <= 0xffffff && value >= 0 then HexColor value
-    else System.ArgumentOutOfRangeException(nameof(value)) |> raise
+    else ArgumentOutOfRangeException(nameof(value)) |> raise
 
   /// Type describing an arbitrary OpenSCAD component.
   /// A component can be a base component, a transformation of a target component, or a combination of multiple components.
@@ -59,29 +60,36 @@ module Components =
       $"[ [{x1}, {y1}, {z1} ], [ {x2}, {y2}, {z2} ], [ {x3}, {y3}, {z3} ] ]"
 
     let componentsToString (toSCADFunc: Component -> string) =
-      List.map toSCADFunc >> List.toArray >> fun strs -> System.String.Join(';', strs) + ";"
+      List.map toSCADFunc >> fun strs -> System.String.Join(';', strs)
 
-    /// Converts a component object to a string containing the OpenSCAD code to generate the component.
-    let rec toSCAD: Component -> string = function
+    let rec toFormattedSCAD (indentLevel: uint) (comp: Component) : string =
+      let indent = String(' ', indentLevel*4u |> int)
+      let subComponent comp = $"{Environment.NewLine}{toFormattedSCAD (indentLevel+1u) comp}"
+      let collection: list<Component> -> string =
+        List.map (subComponent >> fun str -> $"{str};")
+        >> System.String.Concat
+      match comp with
       // Base components
-      | Cube ((x, y, z), center) -> $"cube(size = [{x}, {y}, {z}], center = {boolToString center})"
-      | Sphere (r, d, fa, fs, fn) -> $"sphere(r = {r}, d = {d}, $fa = {fa}, $fs = {fs}, $fn = {fn}"
-      | Cylinder (h, r1, r2, center) -> $"cylinder(h = {h}, r1 = {r1}, r2 = {r2}, center = {boolToString center})"
-      | Polyhedron (points, faces, convexity) -> $"polyhedron(points = {ptsToString points}, faces = {ptsToString faces}, convexity = {convexity})"
+      | Cube ((x, y, z), center) -> $"{indent}cube(size = [{x}, {y}, {z}], center = {boolToString center})"
+      | Sphere (r, d, fa, fs, fn) -> $"{indent}sphere(r = {r}, d = {d}, $fa = {fa}, $fs = {fs}, $fn = {fn}"
+      | Cylinder (h, r1, r2, center) -> $"{indent}cylinder(h = {h}, r1 = {r1}, r2 = {r2}, center = {boolToString center})"
+      | Polyhedron (points, faces, convexity) -> $"{indent}polyhedron(points = {ptsToString points}, faces = {ptsToString faces}, convexity = {convexity})"
       // Transformations of components
-      | Scale ((x, y, z), target) -> $"scale(v = [{x}, {y}, {z}]) {toSCAD target}"
-      | Resize ((x, y, z), target) -> $"resize(newSize = [{x}, {y}, {z}]) {toSCAD target}"
-      | Rotate (a, (x, y, z), target) -> $"rotate(a = {a}, v = [{x}, {y}, {z}]) {toSCAD target}"
-      | Translate ((x, y, z), target) -> $"translate(v = [{x}, {y}, {z}]) {toSCAD target}"
-      | Mirror ((x, y, z), target) -> $"mirror(v = [{x}, {y}, {z}]) {toSCAD target}"
-      | MultiMatrix (m, target) -> $"multimatrix(m = {multiMatrixToString m}) {toSCAD target}"
-      | ColorRGBA ((r, g, b, a), target) -> $"color(c = [{r}, {g}, {b}, {a}]) {toSCAD target}"
-      | ColorHex (c, target) -> $"color(c = {c}) {toSCAD target}"
-      | ColorName (c, target) -> $"color(c = {c}) {toSCAD target}"
-      | Offset (r, delta, chamfer, target) -> $"offset(r = {r}, delta = {delta}, chamfer = {boolToString chamfer}) {toSCAD target}"
-      | Minkowski (target) -> $"minkowski() {toSCAD target}"
-      | Hull (target) -> $"hull() {toSCAD target}"
+      | Scale ((x, y, z), target) -> $"{indent}scale(v = [{x}, {y}, {z}]){subComponent target}"
+      | Resize ((x, y, z), target) -> $"{indent}resize(newSize = [{x}, {y}, {z}]){subComponent target}"
+      | Rotate (a, (x, y, z), target) -> $"{indent}rotate(a = {a}, v = [{x}, {y}, {z}]){subComponent target}"
+      | Translate ((x, y, z), target) -> $"{indent}translate(v = [{x}, {y}, {z}]){subComponent target}"
+      | Mirror ((x, y, z), target) -> $"{indent}mirror(v = [{x}, {y}, {z}]){subComponent target}"
+      | MultiMatrix (m, target) -> $"{indent}multimatrix(m = {multiMatrixToString m}){subComponent target}"
+      | ColorRGBA ((r, g, b, a), target) -> $"{indent}color(c = [{r}, {g}, {b}, {a}]){subComponent target}"
+      | ColorHex (c, target) -> $"{indent}color(c = {c}){subComponent target}"
+      | ColorName (c, target) -> $"{indent}color(c = {c}){subComponent target}"
+      | Offset (r, delta, chamfer, target) -> $"{indent}offset(r = {r}, delta = {delta}, chamfer = {boolToString chamfer}){subComponent target}"
+      | Minkowski (target) -> $"{indent}minkowski(){subComponent target}"
+      | Hull (target) -> $"{indent}hull(){subComponent target}"
       // Combinations of components
-      | Union targets -> $"union() {{ {targets |> componentsToString toSCAD} }}"
-      | Intersection targets -> $"intersection() {{ {targets |> componentsToString toSCAD} }}"
-      | Difference (baseComponent, diffComponents) -> $"difference() {{ {baseComponent :: diffComponents |> componentsToString toSCAD} }}"
+      | Union targets -> $"{indent}union() {{{collection targets}{indent}{Environment.NewLine}}}"
+      | Intersection targets -> $"{indent}intersection() {{{collection targets}{indent}{Environment.NewLine}}}"
+      | Difference (baseComponent, diffComponents) -> $"{indent}difference() {{{collection (baseComponent :: diffComponents)}{indent}{Environment.NewLine}}}"
+
+    let toSCAD comp = toFormattedSCAD 0u comp

--- a/test/FsSCAD.Tests/SCAD_Generation.fs
+++ b/test/FsSCAD.Tests/SCAD_Generation.fs
@@ -2,6 +2,7 @@
 /// Their main purpose is detecting breaking changes.
 module SCAD_Generation
 
+open System
 open FsCheck.Xunit
 open FsSCAD.Components
 
@@ -47,90 +48,95 @@ module Transformations =
   let scale (x, y, z) t =
     Scale(vector = (x, y, z), target = t)
     |> Component.toSCAD
-    |> (=) $"scale(v = [{x}, {y}, {z}]) {Component.toSCAD t}"
+    |> (=) $"scale(v = [{x}, {y}, {z}]){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let resize (x, y, z) t =
     Resize(newSize = (x, y, z), target = t)
     |> Component.toSCAD
-    |> (=) $"resize(newSize = [{x}, {y}, {z}]) {Component.toSCAD t}"
+    |> (=) $"resize(newSize = [{x}, {y}, {z}]){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let rotate a (x, y, z) t =
     Rotate(angle = a, vector = (x, y, z), target = t)
     |> Component.toSCAD
-    |> (=) $"rotate(a = {a}, v = [{x}, {y}, {z}]) {Component.toSCAD t}"
+    |> (=) $"rotate(a = {a}, v = [{x}, {y}, {z}]){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let translate (x, y, z) t =
     Translate(vector = (x, y, z), target = t)
     |> Component.toSCAD
-    |> (=) $"translate(v = [{x}, {y}, {z}]) {Component.toSCAD t}"
+    |> (=) $"translate(v = [{x}, {y}, {z}]){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let mirror (x, y, z) t =
     Mirror(vector = (x, y, z), target = t)
     |> Component.toSCAD
-    |> (=) $"mirror(v = [{x}, {y}, {z}]) {Component.toSCAD t}"
+    |> (=) $"mirror(v = [{x}, {y}, {z}]){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let multiMatrix m t =
     MultiMatrix(mmatrix = m, target = t)
     |> Component.toSCAD
-    |> (=) $"multimatrix(m = {multiMatrixToString m}) {Component.toSCAD t}"
+    |> (=) $"multimatrix(m = {multiMatrixToString m}){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let colorRGBA (r, g, b, a) t =
     ColorRGBA(color = (r, g, b, a), target = t)
     |> Component.toSCAD
-    |> (=) $"color(c = [{r}, {g}, {b}, {a}]) {Component.toSCAD t}"
+    |> (=) $"color(c = [{r}, {g}, {b}, {a}]){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let colorHex c t =
     ColorHex(color = c, target = t)
     |> Component.toSCAD
-    |> (=) $"color(c = {c}) {Component.toSCAD t}"
+    |> (=) $"color(c = {c}){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let colorName c t =
     ColorName(color = c, target = t)
     |> Component.toSCAD
-    |> (=) $"color(c = {c}) {Component.toSCAD t}"
+    |> (=) $"color(c = {c}){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let offset r d c t =
     Offset(r = r, delta = d, chamfer = c, target = t)
     |> Component.toSCAD
-    |> (=) $"offset(r = {r}, delta = {d}, chamfer = {boolToString c}) {Component.toSCAD t}"
+    |> (=) $"offset(r = {r}, delta = {d}, chamfer = {boolToString c}){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let minkowski t =
     Minkowski(target = t)
     |> Component.toSCAD
-    |> (=) $"minkowski() {Component.toSCAD t}"
+    |> (=) $"minkowski(){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
   [<Property>]
   let hull t =
     Hull(target = t)
     |> Component.toSCAD
-    |> (=) $"hull() {Component.toSCAD t}"
+    |> (=) $"hull(){Environment.NewLine}{Component.toFormattedSCAD 1u t}"
 
 module Combinations =
+
+  let formatCollection =
+    List.map (Component.toFormattedSCAD 1u)
+    >> List.map (fun str -> $"{str};{Environment.NewLine}")
+    >> String.concat ""
 
   [<Property>]
   let union ts =
     Union(targets = ts)
     |> Component.toSCAD
-    |> (=) $"union() {{ {ts |> componentsToString Component.toSCAD} }}"
+    |> (=) $"union() {{{Environment.NewLine}{formatCollection ts}}}"
 
   [<Property>]
   let intersection ts =
     Intersection(targets = ts)
     |> Component.toSCAD
-    |> (=) $"intersection() {{ {ts |> componentsToString Component.toSCAD} }}"
+    |> (=) $"intersection() {{{Environment.NewLine}{formatCollection ts}}}"
 
   [<Property>]
   let difference bc dcs =
     Difference(baseComponent = bc, diffComponents = dcs)
     |> Component.toSCAD
-    |> (=) $"difference() {{ {bc :: dcs |> componentsToString Component.toSCAD} }}"
+    |> (=) $"difference() {{{Environment.NewLine}{formatCollection (bc::dcs)}}}"


### PR DESCRIPTION
This PR improves the formatting and readability of generated OpenSCAD code. In particular, newlines and indents are used to visually denote child-parent relationships and break the generated code into many lines, rather than one. This fixes #3.

Prior to PR:
```scad
difference() { cube(size = [3, 3, 24], center = false);translate(v = [1.5, 1.5, 22.75]) rotate(a = 25, v = [0, 0, 1]) cube(size = [1, 6, 2.51], center = true);translate(v = [1.5, 1.5, 22.75]) rotate(a = 80, v = [0, 0, 1]) cube(size = [1, 6, 2.51], center = true);translate(v = [1.5, 1.5, 1.24]) rotate(a = 25, v = [0, 0, 1]) cube(size = [1, 6, 2.49], center = true);translate(v = [1.5, 1.5, 1.24]) rotate(a = 80, v = [0, 0, 1]) cube(size = [1, 6, 2.49], center = true); }
```

After PR:
```scad
difference() {
    cube(size = [3, 3, 24], center = false);
    translate(v = [1.5, 1.5, 22.75])
        rotate(a = 25, v = [0, 0, 1])
            cube(size = [1, 6, 2.51], center = true);
    translate(v = [1.5, 1.5, 22.75])
        rotate(a = 80, v = [0, 0, 1])
            cube(size = [1, 6, 2.51], center = true);
    translate(v = [1.5, 1.5, 1.24])
        rotate(a = 25, v = [0, 0, 1])
            cube(size = [1, 6, 2.49], center = true);
    translate(v = [1.5, 1.5, 1.24])
        rotate(a = 80, v = [0, 0, 1])
            cube(size = [1, 6, 2.49], center = true);
}
```